### PR TITLE
feat: refactors event callbacks and adds support for new event types

### DIFF
--- a/Example-iOS-Swift.xcodeproj/project.pbxproj
+++ b/Example-iOS-Swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3AA84A9C2AC5DA47009C9F5F /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA84A9B2AC5DA47009C9F5F /* Events.swift */; };
 		611368732664FD420014A54E /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611368722664FD420014A54E /* WebViewController.swift */; };
 		61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61136874266503A50014A54E /* WebCacheCleaner.swift */; };
 		6168C9A1265E6C1400754B47 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6168C9A0265E6C1400754B47 /* AppDelegate.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3AA84A9B2AC5DA47009C9F5F /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
 		611368722664FD420014A54E /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		61136874266503A50014A54E /* WebCacheCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCacheCleaner.swift; sourceTree = "<group>"; };
 		6168C99D265E6C1400754B47 /* Example-iOS-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-iOS-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -112,6 +114,7 @@
 				6168C9AE265E6C1600754B47 /* Info.plist */,
 				611368722664FD420014A54E /* WebViewController.swift */,
 				61136874266503A50014A54E /* WebCacheCleaner.swift */,
+				3AA84A9B2AC5DA47009C9F5F /* Events.swift */,
 			);
 			path = "Example-iOS-Swift";
 			sourceTree = "<group>";
@@ -265,6 +268,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AA84A9C2AC5DA47009C9F5F /* Events.swift in Sources */,
 				6168C9A5265E6C1400754B47 /* ViewController.swift in Sources */,
 				61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */,
 				6168C9A1265E6C1400754B47 /* AppDelegate.swift in Sources */,

--- a/Example-iOS-Swift.xcodeproj/project.pbxproj
+++ b/Example-iOS-Swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A84F7C72AC70D4700D3F4DF /* AvatarCreatorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */; };
 		3AA84A9C2AC5DA47009C9F5F /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA84A9B2AC5DA47009C9F5F /* Events.swift */; };
 		611368732664FD420014A54E /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611368722664FD420014A54E /* WebViewController.swift */; };
 		61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61136874266503A50014A54E /* WebCacheCleaner.swift */; };
@@ -38,6 +39,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarCreatorSettings.swift; sourceTree = "<group>"; };
 		3AA84A9B2AC5DA47009C9F5F /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
 		611368722664FD420014A54E /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		61136874266503A50014A54E /* WebCacheCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCacheCleaner.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				611368722664FD420014A54E /* WebViewController.swift */,
 				61136874266503A50014A54E /* WebCacheCleaner.swift */,
 				3AA84A9B2AC5DA47009C9F5F /* Events.swift */,
+				3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */,
 			);
 			path = "Example-iOS-Swift";
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 			files = (
 				3AA84A9C2AC5DA47009C9F5F /* Events.swift in Sources */,
 				6168C9A5265E6C1400754B47 /* ViewController.swift in Sources */,
+				3A84F7C72AC70D4700D3F4DF /* AvatarCreatorSettings.swift in Sources */,
 				61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */,
 				6168C9A1265E6C1400754B47 /* AppDelegate.swift in Sources */,
 				6168C9A3265E6C1400754B47 /* SceneDelegate.swift in Sources */,

--- a/Example-iOS-Swift/AppDelegate.swift
+++ b/Example-iOS-Swift/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 26/5/21.
+//  Created by Ready Player Me on 26/5/21.
 //
 
 import UIKit

--- a/Example-iOS-Swift/AvatarCreatorSettings.swift
+++ b/Example-iOS-Swift/AvatarCreatorSettings.swift
@@ -1,0 +1,97 @@
+//
+//  AvatarCreatorSettings.swift
+//  Example-iOS-Swift
+//
+//  Created by Max Andreassen on 29/09/2023.
+//  Copyright © 2023 Wolf3D. All rights reserved.
+//
+
+import Foundation
+
+enum Language: String {
+    case DEFAULT = ""
+    case CHINESE = "ch"
+    case GERMAN = "de"
+    case ENGLISH_IRELAND = "en-IE"
+    case ENGLISH = "en"
+    case SPANISH_MEXICO = "es-MX"
+    case SPANISH = "es"
+    case FRENCH = "fr"
+    case ITALIAN = "it"
+    case JAPANESE = "jp"
+    case KOREAN = "kr"
+    case PORTUGAL_BRAZIL = "pt-BR"
+    case PORTUGESE = "pt"
+    case TURKISH = "tr"
+}
+
+enum BodyType: String {
+    case SELECTABLE = ""
+    case FULLBODY = "fullbody"
+    case HALFBODY = "halfbody"
+}
+
+enum Gender: String {
+    case NONE = ""
+    case MALE = "male"
+    case FEMALE = "female"
+}
+
+struct AvatarCreatorConfig {
+    // Update to your subdomain URL here
+    var subdomain: String = "demo"
+    var clearCache: Bool = false
+    var quickStart: Bool = false
+    var gender: Gender = .MALE
+    var bodyType: BodyType = .SELECTABLE
+    var loginToken: String = ""
+    var language: Language = .DEFAULT
+}
+
+class AvatarCreatorSettings {
+    private let config: AvatarCreatorConfig
+    
+    init(config: AvatarCreatorConfig) {
+        self.config = config
+    }
+    
+    init() {
+        self.config = AvatarCreatorConfig()
+    }
+    
+    func generateUrl() -> URL {
+        var url = "https://\(config.subdomain).readyplayer.me/"
+        
+        if (config.language != .DEFAULT) {
+            url += "\(config.language.rawValue)/"
+        }
+        
+        url += "avatar?frameApi"
+        
+        if (config.clearCache) {
+            url += "&clearCache"
+        }
+        
+        if (!config.loginToken.isEmpty) {
+            url += "&token=\(config.loginToken)"
+        }
+        
+        if (config.quickStart) {
+            url += "&quickStart"
+        }
+        
+        if (!config.quickStart && config.gender != .NONE) {
+            url += "&gender=\(config.gender.rawValue)"
+        }
+        
+        if (!config.quickStart && config.bodyType == .SELECTABLE) {
+            url += "&selectBodyType"
+        }
+        
+        if (!config.quickStart && config.bodyType != .SELECTABLE) {
+            url += "&bodyType=\(config.bodyType.rawValue)"
+        }
+        
+        return URL(string: url)!
+    }
+}

--- a/Example-iOS-Swift/AvatarCreatorSettings.swift
+++ b/Example-iOS-Swift/AvatarCreatorSettings.swift
@@ -38,7 +38,7 @@ enum Gender: String {
 }
 
 struct AvatarCreatorConfig {
-    // Update to your subdomain URL here
+    // Update your subdomain URL here
     var subdomain: String = "demo"
     var clearCache: Bool = false
     var quickStart: Bool = false

--- a/Example-iOS-Swift/AvatarCreatorSettings.swift
+++ b/Example-iOS-Swift/AvatarCreatorSettings.swift
@@ -3,7 +3,7 @@
 //  Example-iOS-Swift
 //
 //  Created by Max Andreassen on 29/09/2023.
-//  Copyright © 2023 Wolf3D. All rights reserved.
+//  Copyright © 2023 Ready Player Me. All rights reserved.
 //
 
 import Foundation

--- a/Example-iOS-Swift/Base.lproj/Main.storyboard
+++ b/Example-iOS-Swift/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Example-iOS-Swift/Events.swift
+++ b/Example-iOS-Swift/Events.swift
@@ -32,10 +32,17 @@ class UserSetEvent {
 }
 
 class UserAuthorizedEvent {
-    var url: String
+    var id: String
     
-    init (url: String) {
-        self.url = url
+    init (id: String) {
+        self.id = id
     }
 }
 
+class UserUpdatedEvent {
+    var id: String
+    
+    init (id: String) {
+        self.id = id;
+    }
+}

--- a/Example-iOS-Swift/Events.swift
+++ b/Example-iOS-Swift/Events.swift
@@ -9,7 +9,7 @@ class AvatarExportedEvent {
     var url: String
     
     init (url: String) {
-        self.url = url;
+        self.url = url
     }
 }
 
@@ -43,6 +43,6 @@ class UserUpdatedEvent {
     var id: String
     
     init (id: String) {
-        self.id = id;
+        self.id = id
     }
 }

--- a/Example-iOS-Swift/Events.swift
+++ b/Example-iOS-Swift/Events.swift
@@ -3,7 +3,7 @@
 //  Example-iOS-Swift
 //
 //  Created by Max Andreassen on 28/09/2023.
-//  Copyright © 2023 Wolf3D. All rights reserved.
+//  Copyright © 2023 Ready Player Me. All rights reserved.
 //
 class AvatarExportedEvent {
     var url: String

--- a/Example-iOS-Swift/Events.swift
+++ b/Example-iOS-Swift/Events.swift
@@ -1,0 +1,41 @@
+//
+//  Events.swift
+//  Example-iOS-Swift
+//
+//  Created by Max Andreassen on 28/09/2023.
+//  Copyright © 2023 Wolf3D. All rights reserved.
+//
+class AvatarExportedEvent {
+    var url: String
+    
+    init (url: String) {
+        self.url = url;
+    }
+}
+
+class AssetUnlockedEvent {
+    var userId: String
+    var assetId: String
+    
+    init (userId: String, assetId: String) {
+        self.userId = userId
+        self.assetId = assetId
+    }
+}
+
+class UserSetEvent {
+    var id: String
+    
+    init (id: String) {
+        self.id = id
+    }
+}
+
+class UserAuthorizedEvent {
+    var url: String
+    
+    init (url: String) {
+        self.url = url
+    }
+}
+

--- a/Example-iOS-Swift/SceneDelegate.swift
+++ b/Example-iOS-Swift/SceneDelegate.swift
@@ -2,7 +2,7 @@
 //  SceneDelegate.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 26/5/21.
+//  Created by Ready Player Me on 26/5/21.
 //
 
 import UIKit

--- a/Example-iOS-Swift/ViewController.swift
+++ b/Example-iOS-Swift/ViewController.swift
@@ -55,22 +55,30 @@ class ViewController: UIViewController, WebViewDelegate {
         controller.didMove(toParent: self)
     }
     
-    func onAvatarExported(event: AvatarExportedEvent){
+    func onAvatarExported(event: AvatarExportedEvent) {
         showAlert(message: event.url)
         webViewController.view.isHidden = true
         editAvatarButton?.isHidden = false
     }
     
-    func onAssetUnlocked(event: AssetUnlockedEvent){
+    func onAssetUnlocked(event: AssetUnlockedEvent) {
         showAlert(message: "Asset \(event.assetId) unlocked for user \(event.userId)")
     }
     
-    func onUserSet(event: UserSetEvent){
+    func onUserSet(event: UserSetEvent) {
         showAlert(message: "User set:  \(event.id)")
     }
     
-    func onUserAuthorized(event: UserAuthorizedEvent){
-        showAlert(message: "User authorized: \(event.url)")
+    func onUserAuthorized(event: UserAuthorizedEvent) {
+        showAlert(message: "User authorized: \(event.id)")
+    }
+    
+    func onUserUpdated(event: UserUpdatedEvent) {
+        showAlert(message: "User updated: \(event.id)")
+    }
+    
+    func onUserLoggedOut() {
+        showAlert(message: "Logged out.")
     }
     
     func showAlert(message: String){

--- a/Example-iOS-Swift/ViewController.swift
+++ b/Example-iOS-Swift/ViewController.swift
@@ -44,7 +44,7 @@ class ViewController: UIViewController, WebViewDelegate {
             return
         }
         webViewController = viewController
-        webViewController.avatarUrlDelegate = self
+        webViewController.webViewDelegate = self
         
         addChild(controller)
 
@@ -55,14 +55,26 @@ class ViewController: UIViewController, WebViewDelegate {
         controller.didMove(toParent: self)
     }
     
-    func avatarUrlCallback(url: String){
-        showAlert(message: url)
+    func onAvatarExported(event: AvatarExportedEvent){
+        showAlert(message: event.url)
         webViewController.view.isHidden = true
         editAvatarButton?.isHidden = false
     }
     
+    func onAssetUnlocked(event: AssetUnlockedEvent){
+        showAlert(message: "Asset \(event.assetId) unlocked for user \(event.userId)")
+    }
+    
+    func onUserSet(event: UserSetEvent){
+        showAlert(message: "User set:  \(event.id)")
+    }
+    
+    func onUserAuthorized(event: UserAuthorizedEvent){
+        showAlert(message: "User authorized: \(event.url)")
+    }
+    
     func showAlert(message: String){
-        let alert = UIAlertController(title: "Avatar URL Generated", message: message, preferredStyle: .alert)
+        let alert = UIAlertController(title: "Event Received", message: message, preferredStyle: .alert)
 
              let okButton = UIAlertAction(title: "OK", style: .default, handler: { action in
              })

--- a/Example-iOS-Swift/WebCacheCleaner.swift
+++ b/Example-iOS-Swift/WebCacheCleaner.swift
@@ -2,7 +2,7 @@
 //  WebCacheCleaner.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 31/5/21.
+//  Created by Ready Player Me on 31/5/21.
 //
 
 import Foundation

--- a/Example-iOS-Swift/WebViewController.swift
+++ b/Example-iOS-Swift/WebViewController.swift
@@ -13,6 +13,8 @@ protocol WebViewDelegate {
     func onAssetUnlocked(event: AssetUnlockedEvent)
     func onUserSet(event: UserSetEvent)
     func onUserAuthorized(event: UserAuthorizedEvent)
+    func onUserUpdated(event: UserUpdatedEvent)
+    func onUserLoggedOut()
 }
 
 class WebViewController: UIViewController, WKScriptMessageHandler {
@@ -95,8 +97,13 @@ class WebViewController: UIViewController, WKScriptMessageHandler {
                 case "v1.user.set":
                     let event = UserSetEvent (id: bodyStruct.data!["id"]!)
                     webViewDelegate?.onUserSet(event: event)
+                case "v1.user.updated":
+                    let event = UserUpdatedEvent (id: bodyStruct.data!["id"]!)
+                    webViewDelegate?.onUserUpdated(event: event)
+                case "v1.user.logout":
+                    webViewDelegate?.onUserLoggedOut()
                 case "v1.user.authorized":
-                    let event = UserAuthorizedEvent (url: bodyStruct.data!["url"]!)
+                    let event = UserAuthorizedEvent (id: bodyStruct.data!["id"]!)
                     webViewDelegate?.onUserAuthorized(event: event)
                 case "v1.subscription.created":
                     subscriptionCreated = true

--- a/Example-iOS-Swift/WebViewController.swift
+++ b/Example-iOS-Swift/WebViewController.swift
@@ -2,7 +2,7 @@
 //  ViewController.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 26/5/21.
+//  Created by Ready Player Me on 26/5/21.
 //
 import UIKit
 import WebKit

--- a/Example-iOS-Swift/WebViewController.swift
+++ b/Example-iOS-Swift/WebViewController.swift
@@ -22,8 +22,6 @@ class WebViewController: UIViewController, WKScriptMessageHandler {
     var webView: WKWebView!
     let cookieName = "rpm-uid"
     var subscriptionCreated = false
-    //Update to your subdomain URL here
-    let subdomain = "demo"
     
     let source = """
             window.addEventListener('message', function(event){
@@ -115,7 +113,8 @@ class WebViewController: UIViewController, WKScriptMessageHandler {
     }
     
     func reloadPage(clearHistory : Bool){
-        let url = URL(string: "https://\(subdomain).readyplayer.me/avatar?frameApi")!
+        let url = AvatarCreatorSettings().generateUrl();
+        
         if(clearHistory){
             WebCacheCleaner.clean()
         }


### PR DESCRIPTION
SDK-460

FYI, I decided to take the simpler route in the end, and just add the new callbacks along with a little bit of tidying up, and then wrapping the existing exported event inside it's own event payload class.

I did contemplate going further and making this more extensible by removing the switch statement, adding individual files for each event type, and within those classes having the event payload definition and also a uniform method called 'handle'. Then in this proposed approach I would've also had a factory class which would have been responsible for deciding which which callback to call based on the event name. The bonus of this approach is that whenever we need to add new event handlers, you would simply be able to add one new file without touching or extending any existing code, other than referencing the new file in the factory. The reason I ended up deciding against doing this though is that, while it would be more SOLID and extensible, I figured it would add some initial complexity to viewing this code and if it's just meant to be a simple example, and we're unlikely to extend it much, then it probably isn't worth doing adding in that more extensible approach? Would love to get your thoughts though @HarrisonHough.