### PR TITLE
SDK-529 - feat: adds 2D render of image from creator

### DIFF
--- a/Example-iOS-Swift.xcodeproj/project.pbxproj
+++ b/Example-iOS-Swift.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A84F7C72AC70D4700D3F4DF /* AvatarCreatorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */; };
+		3AA84A9C2AC5DA47009C9F5F /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA84A9B2AC5DA47009C9F5F /* Events.swift */; };
 		611368732664FD420014A54E /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611368722664FD420014A54E /* WebViewController.swift */; };
 		61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61136874266503A50014A54E /* WebCacheCleaner.swift */; };
 		6168C9A1265E6C1400754B47 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6168C9A0265E6C1400754B47 /* AppDelegate.swift */; };
@@ -37,6 +39,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarCreatorSettings.swift; sourceTree = "<group>"; };
+		3AA84A9B2AC5DA47009C9F5F /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
 		611368722664FD420014A54E /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		61136874266503A50014A54E /* WebCacheCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCacheCleaner.swift; sourceTree = "<group>"; };
 		6168C99D265E6C1400754B47 /* Example-iOS-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-iOS-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -112,6 +116,8 @@
 				6168C9AE265E6C1600754B47 /* Info.plist */,
 				611368722664FD420014A54E /* WebViewController.swift */,
 				61136874266503A50014A54E /* WebCacheCleaner.swift */,
+				3AA84A9B2AC5DA47009C9F5F /* Events.swift */,
+				3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */,
 			);
 			path = "Example-iOS-Swift";
 			sourceTree = "<group>";
@@ -265,7 +271,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AA84A9C2AC5DA47009C9F5F /* Events.swift in Sources */,
 				6168C9A5265E6C1400754B47 /* ViewController.swift in Sources */,
+				3A84F7C72AC70D4700D3F4DF /* AvatarCreatorSettings.swift in Sources */,
 				61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */,
 				6168C9A1265E6C1400754B47 /* AppDelegate.swift in Sources */,
 				6168C9A3265E6C1400754B47 /* SceneDelegate.swift in Sources */,

--- a/Example-iOS-Swift.xcodeproj/project.pbxproj
+++ b/Example-iOS-Swift.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3A84F7C72AC70D4700D3F4DF /* AvatarCreatorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */; };
 		3AA84A9C2AC5DA47009C9F5F /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA84A9B2AC5DA47009C9F5F /* Events.swift */; };
+		3AB146762AEBB7EA000A6967 /* Avatar2DRenderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB146752AEBB7E9000A6967 /* Avatar2DRenderSettings.swift */; };
 		611368732664FD420014A54E /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611368722664FD420014A54E /* WebViewController.swift */; };
 		61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61136874266503A50014A54E /* WebCacheCleaner.swift */; };
 		6168C9A1265E6C1400754B47 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6168C9A0265E6C1400754B47 /* AppDelegate.swift */; };
@@ -41,6 +42,7 @@
 /* Begin PBXFileReference section */
 		3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarCreatorSettings.swift; sourceTree = "<group>"; };
 		3AA84A9B2AC5DA47009C9F5F /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
+		3AB146752AEBB7E9000A6967 /* Avatar2DRenderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Avatar2DRenderSettings.swift; sourceTree = "<group>"; };
 		611368722664FD420014A54E /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		61136874266503A50014A54E /* WebCacheCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCacheCleaner.swift; sourceTree = "<group>"; };
 		6168C99D265E6C1400754B47 /* Example-iOS-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-iOS-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -118,6 +120,7 @@
 				61136874266503A50014A54E /* WebCacheCleaner.swift */,
 				3AA84A9B2AC5DA47009C9F5F /* Events.swift */,
 				3A84F7C62AC70D4600D3F4DF /* AvatarCreatorSettings.swift */,
+				3AB146752AEBB7E9000A6967 /* Avatar2DRenderSettings.swift */,
 			);
 			path = "Example-iOS-Swift";
 			sourceTree = "<group>";
@@ -276,6 +279,7 @@
 				3A84F7C72AC70D4700D3F4DF /* AvatarCreatorSettings.swift in Sources */,
 				61136875266503A50014A54E /* WebCacheCleaner.swift in Sources */,
 				6168C9A1265E6C1400754B47 /* AppDelegate.swift in Sources */,
+				3AB146762AEBB7EA000A6967 /* Avatar2DRenderSettings.swift in Sources */,
 				6168C9A3265E6C1400754B47 /* SceneDelegate.swift in Sources */,
 				611368732664FD420014A54E /* WebViewController.swift in Sources */,
 			);

--- a/Example-iOS-Swift/AppDelegate.swift
+++ b/Example-iOS-Swift/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 26/5/21.
+//  Created by Ready Player Me on 26/5/21.
 //
 
 import UIKit

--- a/Example-iOS-Swift/Avatar2DRenderSettings.swift
+++ b/Example-iOS-Swift/Avatar2DRenderSettings.swift
@@ -1,0 +1,78 @@
+//
+//  AvatarCreatorSettings.swift
+//  Example-iOS-Swift
+//
+//  Created by Max Andreassen on 29/09/2023.
+//  Copyright © 2023 Ready Player Me. All rights reserved.
+//
+
+import Foundation
+
+enum Expression: String {
+    case DEFAULT = ""
+    case HAPPY = "happy"
+    case LAUGHING = "lol"
+    case SAD = "sad"
+    case SCARED = "scared"
+    case RAGE = "rage"
+}
+
+enum Pose: String {
+    case DEFAULT = ""
+    case THUMBS_UP = "thumbs-up"
+    case POWER_STANCE = "power-stance"
+    case RELAXED = "relaxed"
+    case STANDING = "standing"
+}
+
+enum Camera: String {
+    case DEFAULT = ""
+    case PORTRAIT = "portrait"
+    case FULLBODY = "fullbody"
+}
+
+struct Avatar2DRenderConfig {
+    var expression: Expression = .DEFAULT
+    var pose: Pose = .DEFAULT
+    var camera: Camera = .DEFAULT
+    var quality: Int = 100
+    var size: Int = 512
+    var background: String = "144,89,156" //RGB values separated by commas
+}
+
+class Avatar2DRenderSettings {
+    private let config: Avatar2DRenderConfig
+    
+    init(config: Avatar2DRenderConfig) {
+        self.config = config
+    }
+    
+    init() {
+        self.config = Avatar2DRenderConfig()
+    }
+    
+    func generateUrl(avatarUrl: String) -> URL {
+        var url = avatarUrl.replacingOccurrences(of: ".glb", with: ".png?");
+        
+        if (config.expression != .DEFAULT) {
+            url += "expression=\(config.expression.rawValue)&"
+        }
+        
+        if (config.pose != .DEFAULT) {
+            url += "pose=\(config.pose.rawValue)&"
+        }
+        
+        if (config.camera != .DEFAULT) {
+            url += "camera=\(config.camera.rawValue)&"
+        }
+        
+        if (!(config.background).isEmpty) {
+            url += "background=\(config.background)&"
+        }
+        
+        url += "quality=\(config.quality)&"
+        url += "size=\(config.size)&"
+        
+        return URL(string: url)!
+    }
+}

--- a/Example-iOS-Swift/AvatarCreatorSettings.swift
+++ b/Example-iOS-Swift/AvatarCreatorSettings.swift
@@ -1,0 +1,97 @@
+//
+//  AvatarCreatorSettings.swift
+//  Example-iOS-Swift
+//
+//  Created by Max Andreassen on 29/09/2023.
+//  Copyright © 2023 Ready Player Me. All rights reserved.
+//
+
+import Foundation
+
+enum Language: String {
+    case DEFAULT = ""
+    case CHINESE = "ch"
+    case GERMAN = "de"
+    case ENGLISH_IRELAND = "en-IE"
+    case ENGLISH = "en"
+    case SPANISH_MEXICO = "es-MX"
+    case SPANISH = "es"
+    case FRENCH = "fr"
+    case ITALIAN = "it"
+    case JAPANESE = "jp"
+    case KOREAN = "kr"
+    case PORTUGAL_BRAZIL = "pt-BR"
+    case PORTUGESE = "pt"
+    case TURKISH = "tr"
+}
+
+enum BodyType: String {
+    case SELECTABLE = ""
+    case FULLBODY = "fullbody"
+    case HALFBODY = "halfbody"
+}
+
+enum Gender: String {
+    case NONE = ""
+    case MALE = "male"
+    case FEMALE = "female"
+}
+
+struct AvatarCreatorConfig {
+    // Update your subdomain URL here
+    var subdomain: String = "demo"
+    var clearCache: Bool = false
+    var quickStart: Bool = false
+    var gender: Gender = .MALE
+    var bodyType: BodyType = .SELECTABLE
+    var loginToken: String = ""
+    var language: Language = .DEFAULT
+}
+
+class AvatarCreatorSettings {
+    private let config: AvatarCreatorConfig
+    
+    init(config: AvatarCreatorConfig) {
+        self.config = config
+    }
+    
+    init() {
+        self.config = AvatarCreatorConfig()
+    }
+    
+    func generateUrl() -> URL {
+        var url = "https://\(config.subdomain).readyplayer.me/"
+        
+        if (config.language != .DEFAULT) {
+            url += "\(config.language.rawValue)/"
+        }
+        
+        url += "avatar?frameApi"
+        
+        if (config.clearCache) {
+            url += "&clearCache"
+        }
+        
+        if (!config.loginToken.isEmpty) {
+            url += "&token=\(config.loginToken)"
+        }
+        
+        if (config.quickStart) {
+            url += "&quickStart"
+        }
+        
+        if (!config.quickStart && config.gender != .NONE) {
+            url += "&gender=\(config.gender.rawValue)"
+        }
+        
+        if (!config.quickStart && config.bodyType == .SELECTABLE) {
+            url += "&selectBodyType"
+        }
+        
+        if (!config.quickStart && config.bodyType != .SELECTABLE) {
+            url += "&bodyType=\(config.bodyType.rawValue)"
+        }
+        
+        return URL(string: url)!
+    }
+}

--- a/Example-iOS-Swift/Base.lproj/Main.storyboard
+++ b/Example-iOS-Swift/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Example-iOS-Swift/Base.lproj/Main.storyboard
+++ b/Example-iOS-Swift/Base.lproj/Main.storyboard
@@ -29,30 +29,28 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Ready Player Me " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c58-oT-izA">
-                                <rect key="frame" x="140" y="202" width="131" height="21"/>
+                                <rect key="frame" x="142" y="109" width="131" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CNZ-xq-n3R" userLabel="Edit Avatar Button">
-                                <rect key="frame" x="117" y="790" width="180" height="51"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <color key="tintColor" systemColor="labelColor"/>
-                                <state key="normal" title="Update Avatar" backgroundImage="rectangle.fill" catalog="system">
-                                    <color key="titleColor" systemColor="secondarySystemBackgroundColor"/>
-                                </state>
-                                <connections>
-                                    <action selector="onEditAvatarAction:" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="DkJ-67-vzW"/>
-                                </connections>
-                            </button>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="person.crop.artframe" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="LCY-Ae-M9l" userLabel="Avatar Image">
+                                <rect key="frame" x="87" y="279" width="240" height="240"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="nkN-vJ-Ju0" userLabel="Avatar Loading Indicator">
+                                <rect key="frame" x="160" y="574" width="20" height="20"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                            </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" id="K2a-cO-tOx"/>
                     <connections>
-                        <outlet property="editAvatarButton" destination="CNZ-xq-n3R" id="Sz0-U8-hHI"/>
+                        <outlet property="avatarImage" destination="LCY-Ae-M9l" id="yJZ-Dq-mnY"/>
+                        <outlet property="avatarLoadingIndicator" destination="nkN-vJ-Ju0" id="fNr-Hl-VLd"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -85,6 +83,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="person.crop.artframe" catalog="system" width="115" height="128"/>
         <image name="rectangle.fill" catalog="system" width="128" height="93"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Example-iOS-Swift/Events.swift
+++ b/Example-iOS-Swift/Events.swift
@@ -1,0 +1,48 @@
+//
+//  Events.swift
+//  Example-iOS-Swift
+//
+//  Created by Max Andreassen on 28/09/2023.
+//  Copyright © 2023 Ready Player Me. All rights reserved.
+//
+class AvatarExportedEvent {
+    var url: String
+    
+    init (url: String) {
+        self.url = url
+    }
+}
+
+class AssetUnlockedEvent {
+    var userId: String
+    var assetId: String
+    
+    init (userId: String, assetId: String) {
+        self.userId = userId
+        self.assetId = assetId
+    }
+}
+
+class UserSetEvent {
+    var id: String
+    
+    init (id: String) {
+        self.id = id
+    }
+}
+
+class UserAuthorizedEvent {
+    var id: String
+    
+    init (id: String) {
+        self.id = id
+    }
+}
+
+class UserUpdatedEvent {
+    var id: String
+    
+    init (id: String) {
+        self.id = id
+    }
+}

--- a/Example-iOS-Swift/SceneDelegate.swift
+++ b/Example-iOS-Swift/SceneDelegate.swift
@@ -2,7 +2,7 @@
 //  SceneDelegate.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 26/5/21.
+//  Created by Ready Player Me on 26/5/21.
 //
 
 import UIKit

--- a/Example-iOS-Swift/ViewController.swift
+++ b/Example-iOS-Swift/ViewController.swift
@@ -44,7 +44,7 @@ class ViewController: UIViewController, WebViewDelegate {
             return
         }
         webViewController = viewController
-        webViewController.avatarUrlDelegate = self
+        webViewController.webViewDelegate = self
         
         addChild(controller)
 
@@ -55,14 +55,34 @@ class ViewController: UIViewController, WebViewDelegate {
         controller.didMove(toParent: self)
     }
     
-    func avatarUrlCallback(url: String){
-        showAlert(message: url)
+    func onAvatarExported(event: AvatarExportedEvent) {
+        showAlert(message: event.url)
         webViewController.view.isHidden = true
         editAvatarButton?.isHidden = false
     }
     
+    func onAssetUnlocked(event: AssetUnlockedEvent) {
+        showAlert(message: "Asset \(event.assetId) unlocked for user \(event.userId)")
+    }
+    
+    func onUserSet(event: UserSetEvent) {
+        showAlert(message: "User set:  \(event.id)")
+    }
+    
+    func onUserAuthorized(event: UserAuthorizedEvent) {
+        showAlert(message: "User authorized: \(event.id)")
+    }
+    
+    func onUserUpdated(event: UserUpdatedEvent) {
+        showAlert(message: "User updated: \(event.id)")
+    }
+    
+    func onUserLoggedOut() {
+        showAlert(message: "Logged out.")
+    }
+    
     func showAlert(message: String){
-        let alert = UIAlertController(title: "Avatar URL Generated", message: message, preferredStyle: .alert)
+        let alert = UIAlertController(title: "Event Received", message: message, preferredStyle: .alert)
 
              let okButton = UIAlertAction(title: "OK", style: .default, handler: { action in
              })

--- a/Example-iOS-Swift/ViewController.swift
+++ b/Example-iOS-Swift/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController, WebViewDelegate {
         addChild(controller)
 
         self.view.addSubview(controller.view)
-        controller.view.frame = view.safeAreaLayoutGuide.layoutFrame
+        controller.view.frame = view.bounds
         controller.view.tag = webViewControllerTag
         controller.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         controller.didMove(toParent: self)

--- a/Example-iOS-Swift/ViewController.swift
+++ b/Example-iOS-Swift/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController, WebViewDelegate {
         addChild(controller)
 
         self.view.addSubview(controller.view)
-        controller.view.frame = view.bounds
+        controller.view.frame = view.safeAreaLayoutGuide.layoutFrame
         controller.view.tag = webViewControllerTag
         controller.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         controller.didMove(toParent: self)

--- a/Example-iOS-Swift/ViewController.swift
+++ b/Example-iOS-Swift/ViewController.swift
@@ -9,19 +9,19 @@ import UIKit
 import WebKit
 
 class ViewController: UIViewController, WebViewDelegate {
-    
     let webViewControllerTag = 100
     let webViewIdentifier = "WebViewController"
     var webViewController = WebViewController()
     
-    @IBOutlet weak var editAvatarButton: UIButton!
+    @IBOutlet weak var avatarImage: UIImageView!
+    @IBOutlet weak var avatarLoadingIndicator: UIActivityIndicatorView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         createWebView()
-        editAvatarButton.isHidden = true
         webViewController.view.isHidden = true
-        editAvatarButton.isHidden = !webViewController.hasCookies()
+        self.avatarLoadingIndicator.isHidden = true
+        self.avatarLoadingIndicator.startAnimating()
     }
 
     @IBAction func onCreateNewAvatarAction(_ sender: Any) {
@@ -54,11 +54,10 @@ class ViewController: UIViewController, WebViewDelegate {
         controller.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         controller.didMove(toParent: self)
     }
-    
+
     func onAvatarExported(event: AvatarExportedEvent) {
-        showAlert(message: event.url)
+        renderAvatar(url: event.url)
         webViewController.view.isHidden = true
-        editAvatarButton?.isHidden = false
     }
     
     func onAssetUnlocked(event: AssetUnlockedEvent) {
@@ -79,6 +78,27 @@ class ViewController: UIViewController, WebViewDelegate {
     
     func onUserLoggedOut() {
         showAlert(message: "Logged out.")
+    }
+    
+    func renderAvatar(url: String) {
+        if (url.isEmpty) {
+            return
+        }
+    
+        let avatar2dRenderUrl = Avatar2DRenderSettings().generateUrl(avatarUrl: url);
+        
+        self.avatarLoadingIndicator.isHidden = false;
+            
+        let task = URLSession.shared.dataTask(with: avatar2dRenderUrl) { [weak self] (data, _, _) in
+            if let data = data {
+                DispatchQueue.main.async {
+                    self?.avatarImage.image = UIImage(data: data)
+                    self?.avatarLoadingIndicator.isHidden = true;
+                }
+            }
+        }
+                
+        task.resume();
     }
     
     func showAlert(message: String){

--- a/Example-iOS-Swift/WebCacheCleaner.swift
+++ b/Example-iOS-Swift/WebCacheCleaner.swift
@@ -2,7 +2,7 @@
 //  WebCacheCleaner.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 31/5/21.
+//  Created by Ready Player Me on 31/5/21.
 //
 
 import Foundation

--- a/Example-iOS-Swift/WebViewController.swift
+++ b/Example-iOS-Swift/WebViewController.swift
@@ -28,7 +28,7 @@ class WebViewController: UIViewController, WKScriptMessageHandler {
         let script = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
         config.userContentController.addUserScript(script)
         config.userContentController.add(self, name: "iosListener")
-        webView = WKWebView(frame: .zero, configuration: config)
+        webView = WKWebView(frame: UIScreen.main.bounds, configuration: config)
         view = webView
     }
     

--- a/Example-iOS-Swift/WebViewController.swift
+++ b/Example-iOS-Swift/WebViewController.swift
@@ -28,7 +28,7 @@ class WebViewController: UIViewController, WKScriptMessageHandler {
         let script = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
         config.userContentController.addUserScript(script)
         config.userContentController.add(self, name: "iosListener")
-        webView = WKWebView(frame: UIScreen.main.bounds, configuration: config)
+        webView = WKWebView(frame: .zero, configuration: config)
         view = webView
     }
     

--- a/Example-iOS-Swift/WebViewController.swift
+++ b/Example-iOS-Swift/WebViewController.swift
@@ -2,25 +2,26 @@
 //  ViewController.swift
 //  Example-iOS-Swift
 //
-//  Created by Wolf3D on 26/5/21.
+//  Created by Ready Player Me on 26/5/21.
 //
 import UIKit
 import WebKit
 import Foundation
 
 protocol WebViewDelegate {
-    func avatarUrlCallback(url : String)
+    func onAvatarExported(event: AvatarExportedEvent)
+    func onAssetUnlocked(event: AssetUnlockedEvent)
+    func onUserSet(event: UserSetEvent)
+    func onUserAuthorized(event: UserAuthorizedEvent)
+    func onUserUpdated(event: UserUpdatedEvent)
+    func onUserLoggedOut()
 }
 
 class WebViewController: UIViewController, WKScriptMessageHandler {
-    
-
-    var avatarUrlDelegate:WebViewDelegate?
+    var webViewDelegate:WebViewDelegate?
     var webView: WKWebView!
     let cookieName = "rpm-uid"
     var subscriptionCreated = false
-    //Update to your subdomain URL here
-    let subdomain = "demo"
     
     let source = """
             window.addEventListener('message', function(event){
@@ -78,16 +79,30 @@ class WebViewController: UIViewController, WKScriptMessageHandler {
     }
     
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        
         if let body = message.body as? String{
-            
             let jsonData = body.data(using: .utf8)
             
-            if let bodyStruct = try? JSONDecoder().decode(MessageData.self, from: jsonData!){
+            if let bodyStruct = try? JSONDecoder().decode(MessageData.self, from: jsonData!) {
                 switch bodyStruct.eventName {
                 case "v1.avatar.exported":
-                    avatarUrlDelegate?.avatarUrlCallback(url : bodyStruct.data!["url"]!)
+                    let event = AvatarExportedEvent (url: bodyStruct.data!["url"]!)
+                    webViewDelegate?.onAvatarExported(event: event)
                     reloadPage(clearHistory: false)
+                case "v1.asset.unlock":
+                    let event = AssetUnlockedEvent (userId: bodyStruct.data!["userId"]!,
+                                                    assetId: bodyStruct.data!["assetId"]!)
+                    webViewDelegate?.onAssetUnlocked(event: event)
+                case "v1.user.set":
+                    let event = UserSetEvent (id: bodyStruct.data!["id"]!)
+                    webViewDelegate?.onUserSet(event: event)
+                case "v1.user.updated":
+                    let event = UserUpdatedEvent (id: bodyStruct.data!["id"]!)
+                    webViewDelegate?.onUserUpdated(event: event)
+                case "v1.user.logout":
+                    webViewDelegate?.onUserLoggedOut()
+                case "v1.user.authorized":
+                    let event = UserAuthorizedEvent (id: bodyStruct.data!["id"]!)
+                    webViewDelegate?.onUserAuthorized(event: event)
                 case "v1.subscription.created":
                     subscriptionCreated = true
                 default:
@@ -98,15 +113,12 @@ class WebViewController: UIViewController, WKScriptMessageHandler {
     }
     
     func reloadPage(clearHistory : Bool){
-        let url = URL(string: "https://\(subdomain).readyplayer.me/avatar?frameApi")!
+        let url = AvatarCreatorSettings().generateUrl();
+        
         if(clearHistory){
             WebCacheCleaner.clean()
         }
         webView.load(URLRequest(url: url))
-    }
-
-    func setCallback(delegate: WebViewDelegate){
-        avatarUrlDelegate = delegate
     }
     
     func hasCookies() -> Bool {


### PR DESCRIPTION
This PR adds the 2D rendering of avatars after the avatar creator flow.

Note: This PR also includes the removal of the edit button (the 'create new avatar' button still exists) for two reasons:

1. It seems to have an intermittent issue with the the web creator where it sometimes fails to load when you use edit.
2. It confuses the flow of creation -> 2D render, and removing it led to a more simple example play-through loop.